### PR TITLE
fix!: allow running workers from RunOnStartup, remove RunOnStartup from stream

### DIFF
--- a/samples/DotNet.FunctionApp/Launcher.cs
+++ b/samples/DotNet.FunctionApp/Launcher.cs
@@ -10,8 +10,8 @@ namespace DotNet.FunctionApp
     public static class Launcher
     {
         [FunctionName("Launcher")]
-        public static async Task RunAsync([PerperStreamTrigger(RunOnStartup = true)]
-            PerperStreamContext context,
+        public static async Task RunAsync([PerperModuleTrigger(RunOnStartup = true)]
+            PerperModuleContext context,
             CancellationToken cancellationToken)
         {
             await using var multiGenerator =

--- a/src/Perper.WebJobs.Extensions/Config/PerperStreamTriggerAttribute.cs
+++ b/src/Perper.WebJobs.Extensions/Config/PerperStreamTriggerAttribute.cs
@@ -7,6 +7,5 @@ namespace Perper.WebJobs.Extensions.Config
     [AttributeUsage(AttributeTargets.Parameter)]
     public sealed class PerperStreamTriggerAttribute : Attribute
     {
-        public bool RunOnStartup { get; set; }
     }
 }

--- a/src/Perper.WebJobs.Extensions/Triggers/PerperModuleListener.cs
+++ b/src/Perper.WebJobs.Extensions/Triggers/PerperModuleListener.cs
@@ -56,6 +56,13 @@ namespace Perper.WebJobs.Extensions.Triggers
 
         private async Task ListenAsync(CancellationToken cancellationToken)
         {
+            if (_attribute.RunOnStartup)
+            {
+                var data = _context.GetData($"$launcher.{_delegateName}");
+                await data.StreamActionAsync($"$launcher.{_delegateName}", "", new {});
+                await data.CallWorkerAsync($"$launcher.{_delegateName}", _delegateName, "", new {});
+            }
+
             var triggers = _context.GetNotifications(_delegateName).WorkerTriggers(cancellationToken);
             await foreach (var (streamName, workerName) in triggers.WithCancellation(cancellationToken))
             {


### PR DESCRIPTION
Creates a fake stream so that Perper.Fabric is able to recognize the worker, as discussed on Discord.