### PR TITLE
Implement execution reservations

### DIFF
--- a/agent/dotnet/src/Perper/Application/PerperBuilder.cs
+++ b/agent/dotnet/src/Perper/Application/PerperBuilder.cs
@@ -41,6 +41,8 @@ namespace Perper.Application
                 services.AddScoped<IPerperContext, PerperContext>();
                 services.AddScoped(provider => provider.GetRequiredService<PerperScopeService>().CurrentExecution!);
 
+                services.AddOptions<FabricConfiguration>();
+
                 services.AddOptions<PerperConfiguration>().Configure<ILogger<PerperBuilder>>((configuration, logger) =>
                 {
                     configuration.IgniteEndpoint = Environment.GetEnvironmentVariable("APACHE_IGNITE_ENDPOINT") ?? "127.0.0.1:10800";
@@ -53,6 +55,7 @@ namespace Perper.Application
                     logger.LogInformation("X_PERPER_AGENT: {Agent}", configuration.Agent);
                     logger.LogInformation("X_PERPER_INSTANCE: {Instance}", configuration.Instance);
                 });
+
                 services.AddOptions<IgniteClientConfiguration>().Configure(configuration =>
                 {
                     configuration.BinaryConfiguration = new BinaryConfiguration

--- a/agent/dotnet/src/Perper/Protocol/FabricConfiguration.cs
+++ b/agent/dotnet/src/Perper/Protocol/FabricConfiguration.cs
@@ -1,0 +1,7 @@
+namespace Perper.Protocol
+{
+    public class FabricConfiguration
+    {
+        public string Workgroup { get; set; } = "";
+    }
+}

--- a/agent/dotnet/src/Perper/Protocol/FabricService.Executions.cs
+++ b/agent/dotnet/src/Perper/Protocol/FabricService.Executions.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Channels;
 using System.Threading.Tasks;
 
 using Apache.Ignite.Core.Binary;
@@ -133,7 +131,7 @@ namespace Perper.Protocol
 
                     await stream.RequestStream.WriteAsync(new ReservedExecutionsRequest
                     {
-                        ReserveNext = batchSize
+                        ReserveNext = 1, // TODO: With larger batch sizes, send only when the batch is about to run out.
                     }).ConfigureAwait(false);
                 }
             }

--- a/agent/dotnet/src/Perper/Protocol/FabricService.Executions.cs
+++ b/agent/dotnet/src/Perper/Protocol/FabricService.Executions.cs
@@ -95,43 +95,25 @@ namespace Perper.Protocol
 
         async Task IPerperExecutions.DestroyAsync(PerperExecution execution) => await ExecutionsCache.RemoveAsync(execution.Execution).ConfigureAwait(false);
 
-        private readonly ConcurrentDictionary<(string, string?), bool> _runningExecutionListeners = new();
-        private readonly ConcurrentDictionary<PerperExecutionFilter, Channel<PerperExecutionData>> _executionChannels = new();
-
-        IAsyncEnumerable<PerperExecutionData> IPerperExecutions.ListenAsync(PerperExecutionFilter filter, CancellationToken cancellationToken)
+        async IAsyncEnumerable<PerperExecutionData> IPerperExecutions.ListenAsync(PerperExecutionFilter filter, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            if (filter.Delegate != null)
-            {
-                if (_runningExecutionListeners.TryAdd((filter.Agent, filter.Instance), true))
-                {
-                    TaskCollection.Add(async () =>
-                    {
-                        await foreach (var data in ListenAsyncHelper(filter.Agent, filter.Instance, CancellationTokenSource.Token))
-                        {
-                            var channel = _executionChannels.GetOrAdd(filter with { Delegate = data.Delegate }, _ => Channel.CreateUnbounded<PerperExecutionData>());
-                            await channel.Writer.WriteAsync(data, cancellationToken).ConfigureAwait(false);
-                        }
-                    });
-                }
-
-                var resultChannel = _executionChannels.GetOrAdd(filter, _ => Channel.CreateUnbounded<PerperExecutionData>());
-                return resultChannel.Reader.ReadAllAsync(cancellationToken);
-            }
-            else
-            {
-                return ListenAsyncHelper(filter.Agent, filter.Instance, cancellationToken);
-            }
-        }
-
-        private async IAsyncEnumerable<PerperExecutionData> ListenAsyncHelper(string agent, string? instance, [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
+            var batchSize = (ulong)1; // TODO: Make configurable (PerperExecutionFilter subclass?)
+            var workGroup = Configuration.Workgroup;
             var cancellationTokenSources = new Dictionary<string, CancellationTokenSource>();
 
-            var stream = FabricClient.Executions(new ExecutionsRequest
+            var stream = FabricClient.ReservedExecutions(CallOptions.WithCancellationToken(cancellationToken));
+
+            await stream.RequestStream.WriteAsync(new ReservedExecutionsRequest
             {
-                Agent = agent,
-                Instance = instance ?? "",
-            }, CallOptions.WithCancellationToken(cancellationToken));
+                ReserveNext = batchSize,
+                WorkGroup = workGroup,
+                Filter = new ExecutionsRequest
+                {
+                    Agent = filter.Agent,
+                    Instance = filter.Instance ?? "",
+                    Delegate = filter.Delegate ?? "",
+                }
+            }).ConfigureAwait(false);
 
             while (await stream.ResponseStream.MoveNext(cancellationToken).ConfigureAwait(false))
             {
@@ -143,11 +125,16 @@ namespace Perper.Protocol
                         cts.Cancel();
                     }
                 }
-                else
+                else if (!string.IsNullOrEmpty(executionProto.Execution))
                 {
                     var cts = new CancellationTokenSource();
                     cancellationTokenSources[executionProto.Execution] = cts;
-                    yield return new PerperExecutionData(new PerperAgent(agent, executionProto.Instance), executionProto.Delegate, new PerperExecution(executionProto.Execution), cts.Token);
+                    yield return new PerperExecutionData(new PerperAgent(filter.Agent, executionProto.Instance), executionProto.Delegate, new PerperExecution(executionProto.Execution), cts.Token);
+
+                    await stream.RequestStream.WriteAsync(new ReservedExecutionsRequest
+                    {
+                        ReserveNext = batchSize
+                    }).ConfigureAwait(false);
                 }
             }
         }

--- a/agent/dotnet/src/Perper/Protocol/FabricService.cs
+++ b/agent/dotnet/src/Perper/Protocol/FabricService.cs
@@ -1,15 +1,13 @@
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Apache.Ignite.Core.Binary;
 using Apache.Ignite.Core.Client;
 using Apache.Ignite.Core.Client.Cache;
 
-using Microsoft.Extensions.Options;
-
 using Grpc.Core;
 using Grpc.Net.Client;
+
+using Microsoft.Extensions.Options;
 
 using Perper.Model;
 using Perper.Protocol.Cache;

--- a/agent/dotnet/src/Perper/Protocol/FabricService.cs
+++ b/agent/dotnet/src/Perper/Protocol/FabricService.cs
@@ -6,6 +6,8 @@ using Apache.Ignite.Core.Binary;
 using Apache.Ignite.Core.Client;
 using Apache.Ignite.Core.Client.Cache;
 
+using Microsoft.Extensions.Options;
+
 using Grpc.Core;
 using Grpc.Net.Client;
 
@@ -15,13 +17,14 @@ using Perper.Protocol.Protobuf;
 
 namespace Perper.Protocol
 {
-    public sealed partial class FabricService : IAsyncDisposable, IDisposable, IPerper
+    public sealed partial class FabricService : IPerper //, IAsyncDisposable, IDisposable
     {
-        public FabricService(IIgniteClient ignite, GrpcChannel grpcChannel, IFabricCaster fabricCaster)
+        public FabricService(IIgniteClient ignite, GrpcChannel grpcChannel, IOptions<FabricConfiguration> configuration, IFabricCaster fabricCaster)
         {
             Ignite = ignite;
             FabricClient = new Fabric.FabricClient(grpcChannel);
             FabricCaster = fabricCaster;
+            Configuration = configuration.Value;
 
             IgniteBinary = ignite.GetBinary();
             ExecutionsCache = ignite.GetOrCreateCache<string, ExecutionData>("executions");
@@ -37,6 +40,8 @@ namespace Perper.Protocol
         public IIgniteClient Ignite { get; }
         public IFabricCaster FabricCaster { get; }
 
+        public FabricConfiguration Configuration { get; }
+
         private readonly IBinary IgniteBinary;
         private readonly ICacheClient<string, ExecutionData> ExecutionsCache;
         private readonly ICacheClient<string, StreamListener> StreamListenersCache;
@@ -45,21 +50,20 @@ namespace Perper.Protocol
         private readonly Fabric.FabricClient FabricClient;
         private readonly CallOptions CallOptions = new CallOptions().WithWaitForReady();
 
-        private readonly CancellationTokenSource CancellationTokenSource = new();
-        private readonly TaskCollection TaskCollection = new();
-
         private static long CurrentTicks => DateTime.UtcNow.Ticks - DateTime.UnixEpoch.Ticks;
 
         private static string GenerateName(string? baseName = null) => $"{baseName}-{Guid.NewGuid()}";
+
+        /*
+         * private readonly CancellationTokenSource CancellationTokenSource = new();
+        private readonly TaskCollection TaskCollection = new();
 
         public async ValueTask DisposeAsync()
         {
             CancellationTokenSource.Cancel();
             await TaskCollection.GetTask().ConfigureAwait(false);
             Dispose(true);
-#pragma warning disable CA1816
             GC.SuppressFinalize(this);
-#pragma warning restore CA1816
         }
 
         private void Dispose(bool disposing)
@@ -77,5 +81,6 @@ namespace Perper.Protocol
         }
 
         ~FabricService() => Dispose(false);
+        */
     }
 }

--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     runtimeOnly("org.apache.ignite:ignite-indexing:$igniteVersion")
     implementation("org.apache.ignite:ignite-slf4j:$igniteVersion")
     implementation("org.apache.ignite:ignite-spring:$igniteVersion")
-    runtimeOnly("org.gridgain:control-center-agent:$igniteVersion.0")
+    //runtimeOnly("org.gridgain:control-center-agent:$igniteVersion.0")
     runtimeOnly("org.slf4j:slf4j-simple:$slf4jVersion")
     implementation("javax.annotation:javax.annotation-api:1.2")
     implementation("com.google.protobuf:protobuf-java-util:$protobufVersion")

--- a/proto/fabric.proto
+++ b/proto/fabric.proto
@@ -12,8 +12,14 @@ import "google/protobuf/empty.proto";
 service Fabric {
     rpc Executions (ExecutionsRequest) returns (stream ExecutionsResponse) {}
     rpc AllExecutions (ExecutionsRequest) returns (AllExecutionsResponse) {}
+
     rpc ExecutionFinished (ExecutionFinishedRequest) returns (google.protobuf.Empty) {}
+
+    rpc ReserveExecution (ReserveExecutionRequest) returns (stream google.protobuf.Empty) {}
+    rpc ReservedExecutions (stream ReservedExecutionsRequest) returns (stream ExecutionsResponse) {}
+
     rpc StreamItems (StreamItemsRequest) returns (stream StreamItemsResponse) {}
+
     rpc ListenerAttached (ListenerAttachedRequest) returns (google.protobuf.Empty) {}
 }
 
@@ -24,7 +30,7 @@ message AllExecutionsResponse {
 message ExecutionsRequest {
     string agent = 1;
     string instance = 2;
-    //string delegate = 3;
+    string delegate = 3;
     bool localToData = 4;
 }
 
@@ -37,6 +43,19 @@ message ExecutionsResponse {
     bool cancelled = 5;
 
     bool startOfStream = 10;
+}
+
+message ReservedExecutionsRequest {
+    uint64 reserveNext = 1;
+
+    // Only send with first message:
+    string workGroup = 5;
+    ExecutionsRequest filter = 10;
+}
+
+message ReserveExecutionRequest {
+    string execution = 4;
+    string workGroup = 5;
 }
 
 message ExecutionFinishedRequest {

--- a/samples/dotnet/MultiProcessSample/Calls/Deploy.cs
+++ b/samples/dotnet/MultiProcessSample/Calls/Deploy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Perper.Extensions;
@@ -10,12 +11,14 @@ public static class Deploy
 {
     public static async Task RunAsync()
     {
-        await Task.WhenAll(Enumerable.Range(0, 1).Select(async x =>
+        var nonselfCount = 0;
+        await Task.WhenAll(Enumerable.Range(0, 6).Select(async x =>
         {
             while (true)
             {
                 var responder = await PerperContext.CallAsync<string>("GetProcessName");
                 Console.WriteLine("{0} Got response from {1}", Program.ProcessId, responder);
+                Program.CountReply();
             }
         }));
     }

--- a/samples/dotnet/MultiProcessSample/Calls/Deploy.cs
+++ b/samples/dotnet/MultiProcessSample/Calls/Deploy.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Threading.Tasks;
+
+using Perper.Extensions;
+using Perper.Model;
+
+namespace MultiProcessSample.Calls;
+
+public static class Deploy
+{
+    public static async Task RunAsync()
+    {
+        await Task.WhenAll(Enumerable.Range(0, 1).Select(async x =>
+        {
+            while (true)
+            {
+                var responder = await PerperContext.CallAsync<string>("GetProcessName");
+                Console.WriteLine("{0} Got response from {1}", Program.ProcessId, responder);
+            }
+        }));
+    }
+}

--- a/samples/dotnet/MultiProcessSample/Calls/GetProcessName.cs
+++ b/samples/dotnet/MultiProcessSample/Calls/GetProcessName.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+using Perper.Extensions;
+using Perper.Model;
+
+namespace MultiProcessSample.Calls;
+
+#pragma warning disable CA5394
+
+public static class GetProcessName
+{
+    private static readonly Random random = new();
+    public static async Task<string> RunAsync()
+    {
+        await Task.Delay(random.Next(100, 1000)).ConfigureAwait(false);
+        return $"Name: {Program.ProcessId}";
+    }
+}

--- a/samples/dotnet/MultiProcessSample/Calls/GetProcessName.cs
+++ b/samples/dotnet/MultiProcessSample/Calls/GetProcessName.cs
@@ -14,6 +14,7 @@ public static class GetProcessName
     public static async Task<string> RunAsync()
     {
         await Task.Delay(random.Next(100, 1000)).ConfigureAwait(false);
+        Program.CountResponse();
         return $"Name: {Program.ProcessId}";
     }
 }

--- a/samples/dotnet/MultiProcessSample/MultiProcessSample.csproj
+++ b/samples/dotnet/MultiProcessSample/MultiProcessSample.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\agent\dotnet\src\Perper\Perper.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+  </PropertyGroup>
+
+</Project>

--- a/samples/dotnet/MultiProcessSample/Program.cs
+++ b/samples/dotnet/MultiProcessSample/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading;
 
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Hosting;
 
 using Perper.Application;
@@ -14,6 +16,20 @@ namespace MultiProcessSample;
 public static class Program
 {
     public static Guid ProcessId { get; } = Guid.NewGuid();
+    private static int NonselfCount = 0;
+
+    public static void CountResponse()
+    {
+        Interlocked.Exchange(ref NonselfCount, 0);
+    }
+
+    public static void CountReply()
+    {
+        if (Interlocked.Increment(ref NonselfCount) == 15)
+        {
+            Console.WriteLine("Stuck? \a");
+        }
+    }
 
     public static void Main()
     {
@@ -23,6 +39,9 @@ public static class Program
                 .AddListener(services => new SemaphorePerperListener(5, agent, nameof(GetProcessName), new MethodPerperHandler(GetProcessName.RunAsync, services), services))
                 .AddListener(services => new DeployPerperListener(agent, new MethodPerperHandler(Deploy.RunAsync, services), services))
                 .AddFallbackHandlers(agent)
-        ).Build().Run();
+        ).ConfigureServices(services =>
+        {
+            services.Configure<HostOptions>(o => o.ShutdownTimeout = TimeSpan.FromSeconds(0));
+        }).Build().Run();
     }
 }

--- a/samples/dotnet/MultiProcessSample/Program.cs
+++ b/samples/dotnet/MultiProcessSample/Program.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Threading;
+
+using Microsoft.Extensions.Hosting;
+
+using Perper.Application;
+using Perper.Application.Listeners;
+using Perper.Application.Handlers;
+
+using MultiProcessSample.Calls;
+
+namespace MultiProcessSample;
+
+public static class Program
+{
+    public static Guid ProcessId { get; } = Guid.NewGuid();
+
+    public static void Main()
+    {
+        var agent = "MultiProcessSample";
+        Host.CreateDefaultBuilder().ConfigurePerper(perper =>
+            perper
+                .AddListener(services => new SemaphorePerperListener(5, agent, nameof(GetProcessName), new MethodPerperHandler(GetProcessName.RunAsync, services), services))
+                .AddListener(services => new DeployPerperListener(agent, new MethodPerperHandler(Deploy.RunAsync, services), services))
+                .AddFallbackHandlers(agent)
+        ).Build().Run();
+    }
+}

--- a/samples/dotnet/MultiProcessSample/SemaphorePerperListener.cs
+++ b/samples/dotnet/MultiProcessSample/SemaphorePerperListener.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+using Perper.Application.Listeners;
+using Perper.Application.Handlers;
+using Perper.Model;
+using Perper.Protocol;
+
+#pragma warning disable CA1716
+
+namespace MultiProcessSample
+{
+    [SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates")]
+    [SuppressMessage("Usage", "CA2254:Template should be a static expression")]
+    [SuppressMessage("ReSharper", "TemplateIsNotCompileTimeConstantProblem")]
+    public class SemaphorePerperListener : BackgroundService, IPerperListener
+    {
+        public string Agent { get; }
+        public string Delegate { get; }
+        private readonly IPerperHandler Handler;
+        private readonly IPerper Perper;
+        private readonly PerperListenerFilter Filter;
+        private readonly ILogger<SemaphorePerperListener>? Logger;
+        private readonly SemaphoreSlim ProcessSemaphore;
+
+        public SemaphorePerperListener(int semaphoreCapacity, string agent, string @delegate, IPerperHandler handler, IServiceProvider services)
+        {
+            ProcessSemaphore = new(semaphoreCapacity);
+            Agent = agent;
+            Delegate = @delegate;
+            Handler = handler;
+            Perper = services.GetRequiredService<IPerper>();
+            Filter = services.GetRequiredService<PerperListenerFilter>();
+            Logger = services.GetService<ILogger<SemaphorePerperListener>>();
+        }
+
+        [SuppressMessage("Design", "CA1031: Do not catch general exception types", Justification = "Exception is logged/handled through other means; rethrowing from handler will crash the whole service.")]
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (Filter.Agent != null && Filter.Agent != Agent)
+            {
+                return Task.CompletedTask;
+            }
+
+            var taskCollection = new TaskCollection();
+
+            taskCollection.Add(async () =>
+            {
+                await foreach (var executionData in Perper.Executions.ListenAsync(new PerperExecutionFilter(Agent, Filter.Instance, Delegate), stoppingToken))
+                {
+                    await ProcessSemaphore.WaitAsync();
+                    taskCollection.Add(async () =>
+                    {
+                        Logger?.LogDebug("Executing {Execution}", executionData.Execution);
+                        try
+                        {
+                            var arguments = await Perper.Executions.GetArgumentsAsync(executionData.Execution, Handler.GetParameters()).ConfigureAwait(false);
+
+                            await Handler.Invoke(executionData, arguments).ConfigureAwait(false);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger?.LogError(e, "Exception while handling {Execution}", executionData);
+                            try
+                            {
+                                await Perper.Executions.WriteExceptionAsync(executionData.Execution, e).ConfigureAwait(false);
+                            }
+                            catch (Exception e2)
+                            {
+                                Logger?.LogError(e2, "Exception while writing exception for {Execution}", executionData);
+                            }
+                        }
+                        finally
+                        {
+                            ProcessSemaphore.Release();
+                        }
+                    });
+                }
+            });
+
+            return taskCollection.GetTask();
+        }
+
+        public override string ToString() => $"{GetType()}({Agent}, {Delegate}, {Handler})";
+    }
+}


### PR DESCRIPTION
Leftover issues:

- [x] Improve the distribution of reserved executions, currently the process whose query reserves all of them, even if it can't handle them.
- [ ] Tune batch execution reservation in C# FabricService for performance.
- [ ] Think of ways to avoid having O(active executions * active processors) threads dedicated to operating the IgniteLock-s; maybe using an IgniteQueue somehow?
- [x] Currently, running 5 MultiProcessAgent-s at once deadlocks Fabric within ~5 minutes; yet Ignite remains alive and the Fabric GRPC service continues to accept connections. It is like none of the ScanQuery/ContiniousQuery-s work anymore.